### PR TITLE
0.4.0

### DIFF
--- a/AlbyWidget/src/main/kotlin/com/alby/albywidget/AlbySDK.kt
+++ b/AlbyWidget/src/main/kotlin/com/alby/albywidget/AlbySDK.kt
@@ -2,10 +2,10 @@ package com.alby.widget
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.View
+import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebView
-import android.view.ViewGroup
-import android.view.View
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,6 +36,7 @@ object AlbySDK {
         // Create and load alby js in the background
         val webView = WebView(context)
         webView.settings.javaScriptEnabled = true
+        webView.settings.domStorageEnabled = true
         webView.layoutParams = ViewGroup.LayoutParams(0, 0)  // Zero size
         webView.visibility = View.GONE  // Ensure it's not visible
         webView.loadUrl("https://cdn.alby.com/assets/alby_widget.html?brandId=${brandId}")
@@ -46,7 +47,7 @@ object AlbySDK {
     fun sendPurchasePixel(
         orderId: Any,
         orderTotal: Any,
-        productIds: List<Any>,
+        variantIds: List<Any>,
         currency: String
     ) {
         ensureInitialized()
@@ -55,7 +56,7 @@ object AlbySDK {
             "brand_id" to brandId,
             "order_id" to orderId.toString(),
             "order_total" to orderTotal.toString(),
-            "product_ids" to productIds.joinToString(",") { it.toString() },
+            "variant_ids" to variantIds.joinToString(",") { it.toString() },
             "currency" to currency
         )
 

--- a/AlbyWidget/src/main/kotlin/com/alby/albywidget/WebViewScreen.kt
+++ b/AlbyWidget/src/main/kotlin/com/alby/albywidget/WebViewScreen.kt
@@ -5,12 +5,11 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
 
 @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
@@ -23,14 +22,19 @@ fun WebViewScreen(
     widgetId: String? = null,
     variantId: String? = null,
     component: String? = "alby-mobile-generative-qa",
+    threadId: String? = null,
     testId: String? = null,
     testVersion: String? = null,
-    testDescription: String? = null
+    testDescription: String? = null,
+    focusable: Boolean = false
 ) {
     AndroidView(
         factory = { context ->
             WebView(context).apply {
-                settings.javaScriptEnabled = true
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                }
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(
                         view: WebView?,
@@ -56,24 +60,28 @@ fun WebViewScreen(
                         )
                     }
                 }
-                isFocusable = false
-                isFocusableInTouchMode = false
+                isFocusable = focusable
+                isFocusableInTouchMode = focusable
+                setOverScrollMode(WebView.OVER_SCROLL_NEVER);
+
                 settings.loadWithOverviewMode = false
                 settings.useWideViewPort = true
                 settings.setSupportZoom(false)
-                settings.domStorageEnabled = true
                 addJavascriptInterface(javascriptInterface, "appInterface")
                 webViewReference.value = this
             }
         },
         update = { webView ->
             var widgetUrl =
-                "https://cdn.alby.com/assets/alby_widget.html?brandId=${brandId}&productId=${productId}&component=${component}&useBrandStyling=false"
+                "https://cdn.alby.com/assets/alby_widget.html?brandId=${brandId}&productId=${productId}&component=${component}"
             if (variantId != null) {
                 widgetUrl += "&variantId=${variantId}"
             }
             if (widgetId != null) {
                 widgetUrl += "&widgetId=${widgetId}"
+            }
+            if (threadId != null) {
+                widgetUrl += "&threadId=${threadId}"
             }
             if (testId != null) {
                 widgetUrl += "&testId=${testId}"

--- a/README.md
+++ b/README.md
@@ -71,19 +71,38 @@ import com.alby.widget.AlbyWidgetScreen
 ```
 2. Go to the Activity where you want to place the widget and wrap your existing screen with our widget and pass in the required `brandId`, `productId` and `widgetId` parameters:
 ```kotlin
-AlbyWidgetScreen(brandId = "your-brand-id", productId = "your-product-id", widgetId = "your-widget-id" ) {
- YourScreenGoesHere()
-}
-```
-3. Optional: You can pass in A/B test parameters to the widget by passing in the `testId`, `testVersion` and `testDescription` parameters:
-```kotlin
-AlbyWidgetScreen(brandId = "your-brand-id", productId = "your-product-id", widgetId = "your-widget-id", testId = "your-test-id", testVersion = "your-test-version", testDescription = "your-test-description" ) {
- YourScreenGoesHere()
+AlbyWidgetScreen(
+    brandId = "your-brand-id", 
+    productId = "your-product-id", 
+    widgetId = "your-widget-id",
+    onThreadIdChanged = { newThreadId ->
+        // Handle the new thread ID here
+        // newThreadId will be null if the conversation is reset/cleared
+        println("Thread ID changed to: $newThreadId")
+    }
+) {
+    YourScreenGoesHere()
 }
 ```
 
-The default placement will be in the bottom of the screen. If you have a bottom bar or something similar, make sure you add place the
-bottom sheet around your tab and that you pass the padding for the bottom bar to the widget so it stays on top of the bottom bar.
+3. Optional parameters:
+```kotlin
+AlbyWidgetScreen(
+    brandId = "your-brand-id",
+    productId = "your-product-id",
+    widgetId = "your-widget-id",
+    threadId = "existing-thread-id", // Restore a previous conversation
+    bottomOffset = 56.dp, // Add padding for bottom navigation/bars
+    testId = "your-test-id",
+    testVersion = "your-test-version",
+    testDescription = "your-test-description",
+    onThreadIdChanged = { newThreadId -> 
+        // Handle thread ID changes
+    }
+) {
+    YourScreenGoesHere()
+}
+```
 
 ### AlbyInlineWidget
 The `AlbyInlineWidget` is a component that allows embedding the Alby widget directly into your app's UI. It's perfect for inline use on any page, like product details or brand-specific screens, where the widget integrates seamlessly within the existing view hierarchy.
@@ -92,24 +111,59 @@ The `AlbyInlineWidget` is a component that allows embedding the Alby widget dire
 ```kotlin
 import com.alby.widget.AlbyInlineWidget
 ```
-2. In the Composable function where you want to place the widget, add the `AlbyInlineWidget` component and pass in the required `brandId`, `productId` and `widgetId` parameters:
+
+2. In the Composable function where you want to place the widget, add the `AlbyInlineWidget` component:
 ```kotlin
 AlbyInlineWidget(
-    brandId = "your-brand-id",
-    productId = "your-product-id",
-    widgetId = "your-widget-id"
-)
-```
-3. Optional: You can pass in A/B test parameters to the widget by passing in the `testId`, `testVersion` and `testDescription` parameters:
-```kotlin
-AlbyInlineWidget(
+    modifier = Modifier.padding(24.dp),
     brandId = "your-brand-id",
     productId = "your-product-id",
     widgetId = "your-widget-id",
+    threadId = "existing-thread-id", // Optional: restore a previous conversation
+    onThreadIdChanged = { newThreadId ->
+        // Handle the new thread ID here
+        // newThreadId will be null if the conversation is reset/cleared
+        println("Thread ID changed to: $newThreadId")
+    }
+)
+```
+
+3. Optional parameters:
+```kotlin
+AlbyInlineWidget(
+    modifier = Modifier.padding(24.dp),
+    brandId = "your-brand-id",
+    productId = "your-product-id",
+    widgetId = "your-widget-id",
+    threadId = "existing-thread-id",
     testId = "your-test-id",
     testVersion = "your-test-version",
-    testDescription = "your-test-description"
+    testDescription = "your-test-description",
+    onThreadIdChanged = { newThreadId -> 
+        // Handle thread ID changes
+    }
 )
+```
+
+## Conversation Management
+Both `AlbyWidgetScreen` and `AlbyInlineWidget` support conversation persistence through thread IDs:
+
+1. **Restoring Conversations**: Pass an existing thread ID to continue a previous conversation:
+```kotlin
+threadId = "existing-thread-id"
+```
+
+2. **Tracking Thread Changes**: Listen for thread ID changes to persist conversations:
+```kotlin
+onThreadIdChanged = { newThreadId ->
+    if (newThreadId != null) {
+        // Save the thread ID for later use
+        saveThreadId(newThreadId)
+    } else {
+        // Conversation was reset/cleared
+        clearSavedThreadId()
+    }
+}
 ```
 
 ## Event Tracking
@@ -121,7 +175,7 @@ The SDK also provides an API to sending purchase data and other events via HTTP 
 AlbySDK.sendPurchasePixel(
     orderId = 12345, // Order ID (String or Number)
     orderTotal = 99.99, // Order total (Float or Number)
-    productIds = listOf("A123", 456), // List of product IDs (String or Number)
+    variantIds = listOf("A123", 456), // List of variant IDs (String or Number)
     currency = "USD" // Currency of the order
 )
 ```

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ AlbyWidget for Android requires a SDK 23+ and Jetpack Compose.
 
 ### Gradle Kotlin
 ```
-implementation("com.alby.widget:alby-widget:0.3.0")
+implementation("com.alby.widget:alby-widget:0.4.0")
 ```
 
 ### Gradle
 ```
-implementation 'com.alby.widget:alby-widget:0.3.0'
+implementation 'com.alby.widget:alby-widget:0.4.0'
 ```
 
 ### Apache Maven
@@ -21,7 +21,7 @@ implementation 'com.alby.widget:alby-widget:0.3.0'
 <dependency>
     <groupId>com.alby.widget</groupId>
     <artifactId>alby-widget</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ AlbyWidgetScreen(
     testDescription = "your-test-description",
     onThreadIdChanged = { newThreadId -> 
         // Handle thread ID changes
+    },
+    onWidgetRendered = {
+        // Called when the widget has finished rendering
+        println("Widget is ready!")
     }
 ) {
     YourScreenGoesHere()
@@ -141,6 +145,10 @@ AlbyInlineWidget(
     testDescription = "your-test-description",
     onThreadIdChanged = { newThreadId -> 
         // Handle thread ID changes
+    },
+    onWidgetRendered = {
+        // Called when the widget has finished rendering
+        println("Widget is ready!")
     }
 )
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.nonTransitiveRClass=true
 
 GROUP=com.alby.widget
 POM_ARTIFACT_ID=alby-widget
-VERSION_NAME=0.3.0
+VERSION_NAME=0.4.0
 VERSION_CODE=1
 
 POM_NAME=AlbyWidget

--- a/sample/src/main/java/com/example/sample/MainActivity.kt
+++ b/sample/src/main/java/com/example/sample/MainActivity.kt
@@ -108,6 +108,10 @@ class MainActivity : ComponentActivity() {
                                     productId = "100037",
                                     widgetId = "15b194d9-2641-41f2-a0d7-e258d73d0709",
                                     bottomOffset = bottomPadding,
+                                    onWidgetRendered = {
+                                        // Called when the widget has finished rendering
+                                        println("Widget is ready!")
+                                    }
                                 ) {
                                     LazyColumn {
                                         items(1) {
@@ -131,6 +135,10 @@ class MainActivity : ComponentActivity() {
                                         onThreadIdChanged = { newThreadId ->
                                             // Handle the new thread ID here
                                             println("Thread ID changed to: $newThreadId")
+                                        },
+                                        onWidgetRendered = {
+                                            // Called when the widget has finished rendering
+                                            println("Widget is ready!")
                                         }
                                     )
                                 }

--- a/sample/src/main/java/com/example/sample/MainActivity.kt
+++ b/sample/src/main/java/com/example/sample/MainActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -61,7 +60,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        AlbySDK.initialize("953bfd04-cb12-4b2d-8166-318368479fb0", this)
+        AlbySDK.initialize("c8866843-ce73-496e-b14e-73be14e6450a", this)
 
         setContent {
             // setting up the individual tabs
@@ -105,12 +104,13 @@ class MainActivity : ComponentActivity() {
                         NavHost(navController = navController, startDestination = homeTab.title) {
                             composable(homeTab.title) {
                                 AlbyWidgetScreen(
-                                    brandId = "953bfd04-cb12-4b2d-8166-318368479fb0",
-                                    productId = "alby",
-                                    bottomOffset = bottomPadding
+                                    brandId = "c8866843-ce73-496e-b14e-73be14e6450a",
+                                    productId = "100037",
+                                    widgetId = "15b194d9-2641-41f2-a0d7-e258d73d0709",
+                                    bottomOffset = bottomPadding,
                                 ) {
                                     LazyColumn {
-                                        items(100) {
+                                        items(1) {
                                             Text(homeTab.title)
                                         }
                                     }
@@ -128,6 +128,10 @@ class MainActivity : ComponentActivity() {
                                         brandId = "c8866843-ce73-496e-b14e-73be14e6450a",
                                         modifier = Modifier.padding(24.dp),
                                         productId = "100037",
+                                        onThreadIdChanged = { newThreadId ->
+                                            // Handle the new thread ID here
+                                            println("Thread ID changed to: $newThreadId")
+                                        }
                                     )
                                 }
                             }
@@ -234,7 +238,7 @@ fun MoreView() {
                 AlbySDK.sendPurchasePixel(
                     orderId = 12345,
                     orderTotal = 99.99,
-                    productIds = listOf("A123", 456),
+                    variantIds = listOf("A123", 456),
                     currency = "USD"
                 )
             },


### PR DESCRIPTION
# Release Notes

## Version 0.4.0

### New Features
- Added conversation persistence support through thread IDs
  - New `threadId` parameter to restore previous conversations
  - New `onThreadIdChanged` callback to track conversation thread changes
 -  Added `onWidgetRendered` callback to `AlbyWidgetScreen` and `AlbyInlineWidget` 

### Bug Fixes
- Fixed WebView localStorage initialization issues
- Fixed issue where WebView input elements were not receiving focus in the `AlbyInlineWidget` component
- Fixed keyboard not appearing when tapping input fields in the widget in the `AlbyInlineWidget` component

### Breaking Changes
- Renamed parameter in `sendPurchasePixel` from `productIds` to `variantIds` to match web API

  ```kotlin
  // Before (0.3.0)
  AlbySDK.sendPurchasePixel(
      orderId = 12345,
      orderTotal = 99.99,
      productIds = listOf("A123", 456), // Old parameter name
      currency = "USD"
  )

  // After (0.4.0)
  AlbySDK.sendPurchasePixel(
      orderId = 12345,
      orderTotal = 99.99,
      variantIds = listOf("A123", 456), // New parameter name
      currency = "USD"
  )
  ``` 